### PR TITLE
Update DOCUMENTATION.md

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6,7 +6,7 @@ You can create as many menus as you like in the cp.
 ## Usage
 After creating a menu, add this tag to your front-end to add it to your site. The name corresponds to the name of a menu in the cp:
 
-    {{ bigkahuna menu="custom-name" }}
+    {{ big_kahuna menu="custom-name" }}
 
 Which will return something like this:
 


### PR DESCRIPTION
The documentation for the AddOn says to use this tag: `{{ bigkahuna }}`. This breaks on Linux systems from case sensitivity – Statamic can't find the class to render the tags.

From Statamic docs: 

> Tags are `snake_case` in your templates and `camelCase` in your class.

The class is `BigKahuna`, so the template must use `big_kahuna`.

Closes #23.