### PR TITLE
Fix wrong submenu class

### DIFF
--- a/BigKahuna/BigKahunaTags.php
+++ b/BigKahuna/BigKahunaTags.php
@@ -87,7 +87,7 @@ class BigKahunaTags extends Tags
 
              if ($page['items']) {
                  // Return the submenu html
-                 $html .= $this->getItems($page['items'], false);
+                 $html .= $this->getItems($page['items'], $locale, false);
              }
 
              $html .= '</li>';


### PR DESCRIPTION
The `getItems()` function call in line 90 is missing its second parameter. I think this will fix the `submenu_class` class not rendered as mentioned in [#32 ](https://github.com/Eworm/big-kahuna/issues/32#issuecomment-550222663)