### PR TITLE
Fall back to default title if a content entry exists in a locale

### DIFF
--- a/BigKahuna/BigKahunaController.php
+++ b/BigKahuna/BigKahunaController.php
@@ -285,7 +285,7 @@ class BigKahunaController extends Controller
          $return_entries = [];
          foreach ($entries as $entry) {
             $id = $entry->id();
-            $title = $entry->in($locale)->get('title');
+            $title = $entry->in($locale)->get('title') ?: $entry->get('title');
             if ($entry->contentType() == 'page' && $title != null) {
                 $return_entries[] = [
                     'id'    => $id,


### PR DESCRIPTION
If the title doesn't change between the locales for a content entry it won't always show in the list of all pages.

This commit adds a fall back to return the title in the default locale if it doesn't exist in the localized content.